### PR TITLE
Extend JTSHelper to support EPSG based axis order

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -26,23 +26,33 @@ This project includes:
   Byte Buddy (without dependencies) under The Apache Software License, Version 2.0
   Byte Buddy Java agent under The Apache Software License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
   error-prone annotations under Apache 2.0
   FindBugs-Annotations under GNU Lesser Public License
   FindBugs-jsr305 under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   Hamcrest All under New BSD License
+  HyperSQL Database under HSQLDB License, a BSD open source license
   J2ObjC Annotations under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
   Java Servlet API under CDDL 1.1 or GPL2 w/ CPE
   javax.inject under The Apache Software License, Version 2.0
   JCL 1.2 implemented over SLF4J under MIT License
+  jgridshift under GNU Lesser General Public License, version 2.0 (LGPLv2)
   Joda-Time under Apache 2
+  jsr-275 under BSD License
   JTS Topology Suite under Lesser General Public License (LGPL)
   JUnit under Eclipse Public License 1.0
+  Metadata under Lesser General Public License (LGPL)
   mockito-core under The MIT License
   Objenesis under Apache 2
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Referencing services under Lesser General Public License (LGPL)
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License
   Spring Core under Apache License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <properties>
         <timestamp>${maven.build.timestamp}</timestamp>
         <version.slf4j>1.7.25</version.slf4j>
+        <geotools.version>18.1</geotools.version>
     </properties>
 
     <dependencies>
@@ -249,6 +250,52 @@
             <artifactId>annotations</artifactId>
             <version>3.0.1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-opengis</artifactId>
+            <version>${geotools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${geotools.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_codec</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/n52/shetland/util/JTSHelper.java
+++ b/src/main/java/org/n52/shetland/util/JTSHelper.java
@@ -24,6 +24,7 @@ import com.vividsolutions.jts.geom.CoordinateFilter;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.PrecisionModel;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
@@ -36,13 +37,25 @@ import com.vividsolutions.jts.io.WKTReader;
  */
 public class JTSHelper {
 
-    public static final String WKT_POLYGON = "Polygon";
-    public static final String WKT_POINT = "Point";
     public static final CoordinateFilter COORDINATE_SWITCHING_FILTER = coord -> {
         double tmp = coord.x;
         coord.x = coord.y;
         coord.y = tmp;
     };
+
+    public static final String WKT_POLYGON = "Polygon";
+    public static final String WKT_POINT = "Point";
+
+    /**
+     * WKT format String template for 3D points: <code>Point(%s %s %s)</code>.
+     */
+    public static final String FORMAT_POINT_3D = WKT_POINT + "(%s %s %s)";
+
+    /**
+     * WKT format String template for 2D points: <code>Point(%s %s)</code>.
+     */
+    public static final String FORMAT_POINT_2D = WKT_POINT + "(%s %s)";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(JTSHelper.class);
 
     protected JTSHelper() {
@@ -209,6 +222,41 @@ public class JTSHelper {
 
     public static boolean isNotEmpty(Geometry geometry) {
         return geometry != null && !geometry.isEmpty();
+    }
+
+    /**
+     * Creates a JTS Point from given coordinate values
+     * @param longitude longitude to set
+     * @param latitude latitude to set
+     * @param altitude altitude to set
+     * @param epsgCode EPSG code of the CRS to use
+     * @return a JTS Point with the coordinates in the order Longitude, Latitude, Altitude.
+     * @throws ParseException if the WKT could not be created.
+     *
+     * @see #createGeometryFromWKT(String, int)
+     * @see #FORMAT_POINT_3D
+     */
+    public static Point createPoint(double longitude, double latitude, double altitude, int epsgCode)
+            throws ParseException {
+        return (Point) JTSHelper.createGeometryFromWKT(
+                String.format(altitude == Double.NaN? FORMAT_POINT_2D : FORMAT_POINT_3D, longitude, latitude, altitude),
+                epsgCode);
+    }
+
+    /**
+     * Creates a JTS Point from given coordinate values
+     * @param longitude longitude to set
+     * @param latitude latitude to set
+     * @param epsgCode EPSG code of the CRS to use
+     * @return a JTS Point with the coordinates in the order Longitude, Latitude.
+     * @throws ParseException if the WKT could not be created.
+     *
+     * @see #createGeometryFromWKT(String, int)
+     * @see #FORMAT_POINT_2D
+     */
+    public static Point createPoint(double longitude, double latitude, int epsgCode)
+            throws ParseException {
+        return createPoint(longitude, latitude, Double.NaN, epsgCode);
     }
 
 }

--- a/src/test/java/org/n52/shetland/util/JTSHelperTest.java
+++ b/src/test/java/org/n52/shetland/util/JTSHelperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2017 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.n52.shetland.util;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.io.ParseException;
+
+/**
+ * @author <a href="mailto:e.h.juerrens@52north.org">J&uuml;rrens, Eike Hinderk</a>
+ */
+public class JTSHelperTest {
+
+    private double longitude = 7.5;
+    private double latitude = 52.502;
+    private double altitude = 60;
+
+    @Test
+    public void testCreatePoint3DWGS84() throws ParseException {
+        int epsgCode = 4979;
+        Point jtsPoint = JTSHelper.createPoint(longitude, latitude, altitude, epsgCode);
+
+        assertThat(jtsPoint, notNullValue());
+        assertThat(jtsPoint.getX(), is(longitude));
+        assertThat(jtsPoint.getY(), is(latitude));
+        assertThat(jtsPoint.getCoordinates()[0].z, is(altitude));
+        assertThat(jtsPoint.getSRID(), is(epsgCode));
+    }
+
+    @Test
+    public void testCreatePoint2DWGS84() throws ParseException {
+        int epsgCode = 4326;
+        Point jtsPoint = JTSHelper.createPoint(longitude, latitude, epsgCode);
+
+        assertThat(jtsPoint, notNullValue());
+        assertThat(jtsPoint.getX(), is(longitude));
+        assertThat(jtsPoint.getY(), is(latitude));
+        assertThat(jtsPoint.getCoordinates()[0].z, is(Double.NaN));
+        assertThat(jtsPoint.getSRID(), is(epsgCode));
+    }
+
+}

--- a/src/test/java/org/n52/shetland/util/JTSHelperTest.java
+++ b/src/test/java/org/n52/shetland/util/JTSHelperTest.java
@@ -21,6 +21,9 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.NoSuchAuthorityCodeException;
+
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.io.ParseException;
 
@@ -33,26 +36,29 @@ public class JTSHelperTest {
     private double latitude = 52.502;
     private double altitude = 60;
 
+    // JTS: x,y,z
+    // WGS84: lat (y), long(x), alt(z)
+
     @Test
-    public void testCreatePoint3DWGS84() throws ParseException {
+    public void testCreatePoint3DWGS84() throws ParseException, NoSuchAuthorityCodeException, FactoryException {
         int epsgCode = 4979;
         Point jtsPoint = JTSHelper.createPoint(longitude, latitude, altitude, epsgCode);
 
         assertThat(jtsPoint, notNullValue());
-        assertThat(jtsPoint.getX(), is(longitude));
-        assertThat(jtsPoint.getY(), is(latitude));
+        assertThat(jtsPoint.getX(), is(latitude));
+        assertThat(jtsPoint.getY(), is(longitude));
         assertThat(jtsPoint.getCoordinates()[0].z, is(altitude));
         assertThat(jtsPoint.getSRID(), is(epsgCode));
     }
 
     @Test
-    public void testCreatePoint2DWGS84() throws ParseException {
+    public void testCreatePoint2DWGS84() throws ParseException, NoSuchAuthorityCodeException, FactoryException {
         int epsgCode = 4326;
         Point jtsPoint = JTSHelper.createPoint(longitude, latitude, epsgCode);
 
         assertThat(jtsPoint, notNullValue());
-        assertThat(jtsPoint.getX(), is(longitude));
-        assertThat(jtsPoint.getY(), is(latitude));
+        assertThat(jtsPoint.getX(), is(latitude));
+        assertThat(jtsPoint.getY(), is(longitude));
         assertThat(jtsPoint.getCoordinates()[0].z, is(Double.NaN));
         assertThat(jtsPoint.getSRID(), is(epsgCode));
     }


### PR DESCRIPTION
## Description
- add dependencies for EPSG database:
  - gt-referencing
  - gt-opengis
  - gt-epsg-hsql
- add two methods to `JTSHelper`:
  - `public static Point createPoint(double longitude, double latitude, double altitude, int epsgCode)`
  - `public static Point createPoint(double longitude, double latitude, int epsgCode)`

## Issues/Questions
- [ ] Do we want to have functionality like this in shetland?
- [ ] Should be put it into janmayen?
- [ ] Any other issues?